### PR TITLE
Fix translator form submission and back button

### DIFF
--- a/js/traductor.js
+++ b/js/traductor.js
@@ -42,6 +42,11 @@ document.addEventListener('DOMContentLoaded', () => {
     scrollAbajo();
   }
 
+  // Alias compatible con otras implementaciones
+  function agregarBurbuja(texto, clase) {
+    agregarMensaje(texto, clase);
+  }
+
   function mostrarPensando() {
     const mensaje = document.createElement('div');
     mensaje.className = 'mensaje sparkie';
@@ -79,7 +84,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   btnRegresar.addEventListener('click', () => {
-    window.location.href = 'index.html';
+    window.history.back();
   });
 
   textarea.addEventListener('keydown', e => {
@@ -94,7 +99,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const texto = textarea.value.trim();
     if (!texto) return;
 
-    agregarMensaje(texto, 'usuario');
+    agregarBurbuja(texto, 'usuario');
     textarea.value = '';
     mostrarPensando();
 
@@ -107,22 +112,22 @@ document.addEventListener('DOMContentLoaded', () => {
 
       eliminarPensando();
       if (!res.ok) {
-        agregarMensaje('Error al traducir.', 'sparkie');
+        agregarBurbuja('Error al traducir.', 'sparkie');
         return;
       }
       const data = await res.json();
       if (data.traduccion) {
-        agregarMensaje(data.traduccion, 'sparkie');
+        agregarBurbuja(data.traduccion, 'sparkie');
         if (sonidoActivo) {
           sonido.currentTime = 0;
           sonido.play();
         }
       } else {
-        agregarMensaje('No se recibió una traducción válida.', 'sparkie');
+        agregarBurbuja('No se recibió una traducción válida.', 'sparkie');
       }
     } catch (err) {
       eliminarPensando();
-      agregarMensaje('Error de conexión.', 'sparkie');
+      agregarBurbuja('Error de conexión.', 'sparkie');
     }
   });
 });


### PR DESCRIPTION
## Summary
- add `agregarBurbuja` wrapper for compatibility
- send messages using `agregarBurbuja`
- use `window.history.back()` for the return button

## Testing
- `node --check js/traductor.js`

------
https://chatgpt.com/codex/tasks/task_e_684114ed5a34832b868d70ae8c8d8124