### PR TITLE
Implement term comparison page

### DIFF
--- a/comparador.html
+++ b/comparador.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Comparador de Términos - Diccionario AR</title>
+  <link rel="stylesheet" href="css/comparador.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
+</head>
+<body>
+  <div class="contenedor">
+    <header class="header">
+      <button id="btn-volver" title="Volver al diccionario" aria-label="Volver al diccionario">
+        <i class="fas fa-arrow-left"></i>
+      </button>
+      <h1>Comparador de Términos</h1>
+    </header>
+
+    <div class="selectors">
+      <select id="termino1" aria-label="Término 1">
+        <option value="">Selecciona término 1</option>
+      </select>
+      <select id="termino2" aria-label="Término 2">
+        <option value="">Selecciona término 2</option>
+      </select>
+      <button id="comparar" class="btn-comparar">Comparar</button>
+    </div>
+
+    <div id="resultados" class="resultados"></div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="js/comparador.js"></script>
+</body>
+</html>

--- a/css/comparador.css
+++ b/css/comparador.css
@@ -1,0 +1,98 @@
+body {
+  margin: 0;
+  padding: 20px;
+  font-family: 'Segoe UI', sans-serif;
+  background: linear-gradient(to bottom, #0f1115, #1a1c22);
+  color: #fff;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+}
+
+.contenedor {
+  width: 100%;
+  max-width: 1000px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.header h1 {
+  flex-grow: 1;
+  font-size: 1.6rem;
+  text-align: center;
+}
+
+.header button {
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+
+.selectors {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+  margin-bottom: 20px;
+}
+
+.selectors select,
+.selectors button {
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid #555;
+  background: #222;
+  color: #fff;
+  font-size: 1rem;
+}
+
+.selectors button {
+  background: #1877f2;
+  border: none;
+  cursor: pointer;
+  color: #fff;
+}
+
+.resultados {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.campo {
+  background: rgba(255, 255, 255, 0.05);
+  padding: 10px;
+  border-radius: 8px;
+  border: 1px solid #444;
+}
+
+.campo.diferente {
+  background: rgba(255, 92, 57, 0.3);
+}
+
+.campo img {
+  max-width: 100%;
+  height: auto;
+  margin-top: 6px;
+}
+
+.sinonimos span {
+  display: inline-block;
+  margin: 4px 6px 4px 0;
+  padding: 4px 10px;
+  border-radius: 16px;
+  background-color: #444;
+  font-style: italic;
+}
+
+@media (max-width: 700px) {
+  .resultados {
+    grid-template-columns: 1fr;
+  }
+}

--- a/js/comparador.js
+++ b/js/comparador.js
@@ -1,0 +1,97 @@
+const supabaseUrl = 'https://gapivzjnehrkbbnjtvam.supabase.co';
+const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdhcGl2empuZWhya2Jibmp0dmFtIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg0NjkwMzYsImV4cCI6MjA2NDA0NTAzNn0.g7MXXPDzBqssewgHUreA_jNbRl7A_gTvaTv2xXEwHTk';
+const supabase = window.supabase.createClient(supabaseUrl, supabaseKey);
+
+let glosario = [];
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const { data, error } = await supabase.from('base_datos').select('*');
+  if (error) {
+    console.error('Error al cargar glosario', error);
+    return;
+  }
+  glosario = data;
+  poblarSelects();
+
+  document.getElementById('comparar').addEventListener('click', comparar);
+  document.getElementById('btn-volver')?.addEventListener('click', () => {
+    window.location.href = 'index.html';
+  });
+});
+
+function poblarSelects() {
+  const ordenados = [...glosario].sort((a, b) => a.termino.localeCompare(b.termino));
+  const sel1 = document.getElementById('termino1');
+  const sel2 = document.getElementById('termino2');
+  ordenados.forEach(item => {
+    const opt1 = new Option(item.termino, item.termino);
+    const opt2 = new Option(item.termino, item.termino);
+    sel1.appendChild(opt1);
+    sel2.appendChild(opt2);
+  });
+}
+
+function obtener(nombre) {
+  return glosario.find(t => t.termino === nombre) || {};
+}
+
+function comparar() {
+  const nombre1 = document.getElementById('termino1').value;
+  const nombre2 = document.getElementById('termino2').value;
+  if (!nombre1 || !nombre2 || nombre1 === nombre2) {
+    alert('Selecciona dos términos distintos');
+    return;
+  }
+  const t1 = obtener(nombre1);
+  const t2 = obtener(nombre2);
+  mostrarComparacion(t1, t2);
+}
+
+function mostrarComparacion(a, b) {
+  const campos = [
+    ['termino', 'Nombre'],
+    ['traduccion', 'Traducción'],
+    ['pronunciacion', 'Pronunciación'],
+    ['categoria', 'Categoría'],
+    ['definicion', 'Definición'],
+    ['sinonimos', 'Sinónimos'],
+    ['tipo_termino', 'Tipo'],
+    ['imagen', 'Imagen']
+  ];
+  const cont = document.getElementById('resultados');
+  cont.innerHTML = '';
+
+  campos.forEach(([clave, etiqueta]) => {
+    const v1 = a[clave] || '';
+    const v2 = b[clave] || '';
+    const div1 = document.createElement('div');
+    const div2 = document.createElement('div');
+    div1.className = 'campo';
+    div2.className = 'campo';
+    div1.innerHTML = generarHTML(etiqueta, v1, clave);
+    div2.innerHTML = generarHTML(etiqueta, v2, clave);
+    if (normalizar(v1) !== normalizar(v2)) {
+      div1.classList.add('diferente');
+      div2.classList.add('diferente');
+    }
+    cont.appendChild(div1);
+    cont.appendChild(div2);
+  });
+}
+
+function generarHTML(label, valor, clave) {
+  if (clave === 'imagen' && valor) {
+    const url = valor.startsWith('http') ? valor :
+      `https://gapivzjnehrkbbnjtvam.supabase.co/storage/v1/object/public/instrumentos/${valor.trim()}`;
+    return `<strong>${label}:</strong><br><img src="${url}" alt="${label}">`;
+  }
+  if (clave === 'sinonimos' && valor) {
+    const s = valor.split(',').map(v => `<span>${v.trim()}</span>`).join(' ');
+    return `<strong>${label}:</strong><br><div class="sinonimos">${s}</div>`;
+  }
+  return `<strong>${label}:</strong> ${valor || '-'}`;
+}
+
+function normalizar(t) {
+  return (t || '').toString().trim().toLowerCase();
+}


### PR DESCRIPTION
## Summary
- add new page `comparador.html` to compare two terms
- style comparison with `css/comparador.css`
- load glossary and display differences via `js/comparador.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684127ad17fc832b9a2ab5ea7f47b1bd