### PR TITLE
Add PWA support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
-*.png binary
-*.ico binary
-*.mp3 binary
+*.png filter=lfs diff=lfs merge=lfs -text
+*.ico filter=lfs diff=lfs merge=lfs -text
+*.mp3 filter=lfs diff=lfs merge=lfs -text

--- a/admin.html
+++ b/admin.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Panel de Administración - Diccionario AR</title>
+  <link rel="manifest" href="manifest.webmanifest">
+  <meta name="theme-color" content="#00FFD0" />
   <link rel="stylesheet" href="css/admin.css">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
   <script defer src="js/admin.js"></script>

--- a/agregar.html
+++ b/agregar.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Agregar Término - Diccionario AR</title>
+  <link rel="manifest" href="manifest.webmanifest">
+  <meta name="theme-color" content="#00FFD0" />
   <link rel="icon" type="image/png" href="favicon-ar.png">
   <link rel="stylesheet" href="css/agregar.css" />
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>

--- a/chat-sparkie.html
+++ b/chat-sparkie.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Chat con Sparkie IA</title>
+  <link rel="manifest" href="manifest.webmanifest" />
+  <meta name="theme-color" content="#00FFD0" />
   
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-REW5RZ32MX"></script>

--- a/img/sparkie-icon.png
+++ b/img/sparkie-icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5beb8251872d20b4fbff8d1a207363679a849e3208f43ba2b5b127392ff4ad2e
+size 24871

--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Diccionario - AR</title>
+  <link rel="manifest" href="manifest.webmanifest" />
+  <meta name="theme-color" content="#00FFD0" />
 
   <!-- Google tag -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-REW5RZ32MX"></script>

--- a/inicio.html
+++ b/inicio.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Inicio - Diccionario AR</title>
+  <link rel="manifest" href="manifest.webmanifest">
+  <meta name="theme-color" content="#00FFD0" />
   <link rel="stylesheet" href="css/inicio.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.1/dist/aos.css">

--- a/js/main.js
+++ b/js/main.js
@@ -278,11 +278,9 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 
 if ('serviceWorker' in navigator) {
-  window.addEventListener('load', () => {
-    navigator.serviceWorker.register('serviceWorker.js')
-      .then(reg => console.log('✅ SW registrado:', reg.scope))
-      .catch(err => console.error('❌ Error SW:', err));
-  });
+  navigator.serviceWorker.register('/serviceWorker.js')
+    .then(reg => console.log('✅ Service Worker registrado', reg))
+    .catch(err => console.error('❌ Error al registrar SW', err));
 }
 
 window.buscar = buscar;

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,20 @@
+{
+  "name": "Diccionario AR",
+  "short_name": "Diccionario",
+  "icons": [
+    {
+      "src": "img/sparkie-icon.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "favicon-ar.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "start_url": "/index.html",
+  "background_color": "#0a0a0a",
+  "theme_color": "#00FFD0",
+  "display": "standalone"
+}

--- a/revisar-sugerencias.html
+++ b/revisar-sugerencias.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Revisar Sugerencias - Diccionario AR</title>
+    <link rel="manifest" href="manifest.webmanifest" />
+    <meta name="theme-color" content="#00FFD0" />
     <link rel="icon" type="image/png" href="favicon-ar.png">
     <link rel="shortcut icon" href="favicon-ar.ico" type="image/x-icon">
     <link rel="stylesheet" href="css/revisar-sugerencias.css">

--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -1,59 +1,57 @@
-const CACHE_NAME = "diccionario-ar-cache-v3";
+const CACHE_NAME = 'diccionario-ar-v4';
 
-const urlsToCache = [
-  "/",
-  "/index.html",
-  "/admin.html",
-  "/agregar.html",
-  "/sugerencias.html",
-  "/revisar-sugerencias.html",
-  "/traductor.html",
-  "/favicon-ar.png",
-  "/favicon-ar.ico",
-  "/fonts/Middle-of-April.ttf",
-  "/img/FONDOOO.jpeg",
-  "/img/fondo-claro.png",
-  "/css/estilos.css",
-  "/css/admin.css",
-  "/css/agregar.css",
-  "/css/sugerencias.css",
-  "/css/revisar-sugerencias.css",
-  "/css/traductor.css",
-  "/js/main.js",
-  "/js/admin.js",
-  "/js/agregar.js",
-  "/js/sugerencias.js",
-  "/js/revisar-sugerencias.js",
-  "/js/traductor.js"
+const STATIC_ASSETS = [
+  '/',
+  '/index.html',
+  '/inicio.html',
+  '/admin.html',
+  '/agregar.html',
+  '/sugerencias.html',
+  '/revisar-sugerencias.html',
+  '/chat-sparkie.html',
+  '/css/estilos.css',
+  '/css/inicio.css',
+  '/css/admin.css',
+  '/css/agregar.css',
+  '/css/sugerencias.css',
+  '/css/revisar-sugerencias.css',
+  '/css/chat-sparkie.css',
+  '/js/main.js',
+  '/js/inicio.js',
+  '/js/admin.js',
+  '/js/agregar.js',
+  '/js/sugerencias.js',
+  '/js/revisar-sugerencias.js',
+  '/js/chat-sparkie.js',
+  '/img/sparkie-icon.png',
+  '/favicon-ar.png'
 ];
 
-self.addEventListener("install", (event) => {
-  self.skipWaiting(); // ✅ activa de inmediato
+self.addEventListener('install', event => {
+  self.skipWaiting();
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => {
-      return cache.addAll(urlsToCache);
-    })
+    caches.open(CACHE_NAME).then(cache => cache.addAll(STATIC_ASSETS))
   );
 });
 
-self.addEventListener("activate", (event) => {
+self.addEventListener('activate', event => {
   event.waitUntil(
-    caches.keys().then((cacheNames) =>
-      Promise.all(
-        cacheNames.map((name) => {
-          if (name !== CACHE_NAME) {
-            return caches.delete(name);
-          }
-        })
-      )
+    caches.keys().then(keys =>
+      Promise.all(keys.map(key => key !== CACHE_NAME && caches.delete(key)))
     )
   );
+  self.clients.claim();
 });
 
-self.addEventListener("fetch", (event) => {
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
   event.respondWith(
     fetch(event.request)
-      .then((response) => response)
+      .then(res => {
+        const resClone = res.clone();
+        caches.open(CACHE_NAME).then(cache => cache.put(event.request, resClone));
+        return res;
+      })
       .catch(() => caches.match(event.request))
   );
 });

--- a/sugerencias.html
+++ b/sugerencias.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Sugerencias - Diccionario AR</title>
+  <link rel="manifest" href="manifest.webmanifest">
+  <meta name="theme-color" content="#00FFD0" />
   
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-REW5RZ32MX"></script>


### PR DESCRIPTION
## Summary
- add web manifest and service worker
- register service worker from `main.js`
- link the manifest in all main pages
- include new 192x192 icon for PWA
- track binary assets with Git LFS

## Testing
- `git lfs version`


------
https://chatgpt.com/codex/tasks/task_e_684647e85f94832b8c2498aad0a00770