### PR TITLE
Improve mobile styles

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -147,7 +147,7 @@ button {
   margin-top: 10px;
   transition: background-color 0.3s, transform 0.2s ease;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-  min-height: 44px;
+  min-height: 48px;
 }
 
 button:hover,
@@ -266,7 +266,7 @@ body.light-mode #tablaTerminos tr:hover {
   border-radius: 4px;
   cursor: pointer;
   font-weight: bold;
-  min-height: 44px;
+  min-height: 48px;
 }
 
 #paginacion button:disabled {

--- a/css/agregar.css
+++ b/css/agregar.css
@@ -86,6 +86,8 @@ body.light-mode #toggle-modo::before {
   border-radius: 20px;
   width: 100%;
   max-width: 600px;
+  max-height: 90vh;
+  overflow-y: auto;
   box-shadow: 0 0 20px rgba(0,0,0,0.5);
   animation: fadeIn 0.5s ease-in-out;
 }
@@ -114,7 +116,7 @@ button {
   border-radius: 8px;
   border: none;
   box-sizing: border-box;
-  min-height: 44px; /* ✅ tamaño táctil */
+  min-height: 48px; /* ✅ tamaño táctil */
 }
 
 input,
@@ -190,7 +192,7 @@ button:focus-visible {
   margin: 0 10px;
   background-color: #444;
   color: white;
-  min-height: 44px;
+  min-height: 48px;
 }
 
 body.light-mode .barra-inferior {

--- a/css/chat-modal.css
+++ b/css/chat-modal.css
@@ -55,7 +55,7 @@ body.dark-mode {
 #sparkie-modal .chat-body::-webkit-scrollbar-thumb { background-color: rgba(0,0,0,0.2); border-radius:10px; }
 #sparkie-modal .chat-body::-webkit-scrollbar-track { background-color: transparent; }
 #sparkie-modal .chat-form { display:flex; border-top:1px solid #ddd; padding:0.75rem; gap:0.5rem; }
-#sparkie-modal .chat-form textarea { flex:1; padding:0.6rem 1rem; border-radius:12px; border:1px solid #ccc; font-size:1rem; resize:none; height:42px; line-height:1.3; }
+#sparkie-modal .chat-form textarea { flex:1; padding:0.6rem 1rem; border-radius:12px; border:1px solid #ccc; font-size:1rem; resize:none; min-height:48px; line-height:1.3; }
 #sparkie-modal .chat-form textarea:focus { border-color: var(--sparkie-user); outline:none; box-shadow:0 0 4px var(--sparkie-user); }
 #sparkie-modal .chat-form button { background:#ff5c39; color:white; border:none; border-radius:20px; padding:0.6rem 1.2rem; cursor:pointer; font-weight:bold; }
 #sparkie-modal .chat-form button:hover { background:#e44827; }
@@ -70,4 +70,12 @@ body.dark-mode {
 #sparkie-modal .burbuja.pensando { font-style: italic; opacity:0.6; position:relative; }
 #sparkie-modal .burbuja.pensando::after { content:' .'; animation:puntos 1s steps(3,end) infinite; }
 @keyframes puntos {0%{content:' .';}33%{content:' ..';}66%{content:' ...';}100%{content:' .';}}
+
+@media (max-width: 600px) {
+  #sparkie-modal .chat-container {
+    width: 95vw;
+    height: 90vh;
+    border-radius: 12px;
+  }
+}
 

--- a/css/chat-sparkie.css
+++ b/css/chat-sparkie.css
@@ -101,7 +101,7 @@ body.dark-mode .chat-container {
   border: 1px solid #ccc;
   font-size: 1rem;
   resize: none;
-  height: 42px;
+  min-height: 48px;
   line-height: 1.3;
 }
 
@@ -229,4 +229,12 @@ body.dark-mode .chat-container {
 .botones-header button:hover i.fas {
   color: var(--user-bubble);
   transform: scale(1.2);
+}
+
+@media (max-width: 600px) {
+  .chat-container {
+    width: 95vw;
+    height: 90vh;
+    border-radius: 12px;
+  }
 }

--- a/css/comparador.css
+++ b/css/comparador.css
@@ -50,7 +50,7 @@ body {
   background: #222;
   color: #fff;
   font-size: 1rem;
-  min-height: 44px; /* ✅ tamaño táctil */
+  min-height: 48px; /* ✅ tamaño táctil */
 }
 
 .selectors select {
@@ -86,6 +86,7 @@ body {
   padding: 10px;
   border-radius: 8px;
   border: 1px solid #444;
+  overflow-wrap: anywhere;
 }
 
 .campo.diferente {

--- a/css/contacto.css
+++ b/css/contacto.css
@@ -82,6 +82,8 @@ main p {
   display: flex;
   flex-direction: column;
   gap: 20px;
+  max-height: 90vh;
+  overflow-y: auto;
 }
 
 .formulario-contacto label {
@@ -116,7 +118,7 @@ main p {
   font-size: 1rem;
   cursor: pointer;
   transition: background 0.3s;
-  min-height: 44px; /* ✅ tamaño táctil */
+  min-height: 48px; /* ✅ tamaño táctil */
 }
 
 .btn-enviar:hover {

--- a/css/estilos.css
+++ b/css/estilos.css
@@ -60,7 +60,7 @@ body.light-mode {
   box-shadow: 0 4px 8px rgba(0,0,0,0.2);
   cursor: pointer;
   transition: background-color 0.3s ease, transform 0.3s ease;
-  min-height: 44px; /* ✅ tamaño táctil adecuado */
+  min-height: 48px; /* ✅ tamaño táctil adecuado */
 }
 .boton:hover {
   background-color: #3ae374;
@@ -129,6 +129,7 @@ h1 span {
   color: #111;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
   transition: all 0.3s ease;
+  min-height: 48px;
 }
 body.light-mode .busqueda input {
   background-color: #f3f3f3;
@@ -167,6 +168,7 @@ body.light-mode .ventana {
   border-radius: 10px;
   color: white;
   text-align: left;
+  overflow-wrap: anywhere;
   white-space: normal;
   font-size: 15px;
   line-height: 1.6;
@@ -317,7 +319,7 @@ body.light-mode #toggle-modo::before {
   z-index: 1001;
 }
 .nav-flotante button {
-  min-height: 44px;
+  min-height: 48px;
   padding: 8px 16px;
   font-weight: 600;
   font-size: 0.9rem;
@@ -580,12 +582,14 @@ body {
   z-index: 1001;
   max-width: 400px;
   width: 90%;
+  overflow-wrap: anywhere;
 }
 .ventana-sugerencia textarea,
 .ventana-sugerencia input {
   width: 100%;
   margin-bottom: 10px;
   padding: 8px;
+  min-height: 48px;
 }
 .ventana-sugerencia .botones-form {
   display: flex;
@@ -627,5 +631,11 @@ body {
   }
   .resultado-flex {
     flex-direction: column;
+  }
+
+  .ventana-sugerencia {
+    top: 10%;
+    max-height: 80vh;
+    overflow-y: auto;
   }
 }

--- a/css/inicio.css
+++ b/css/inicio.css
@@ -163,6 +163,8 @@ section {
   border-radius: 12px;
   padding: 20px;
   width: 260px;
+  max-width: 100%;
+  overflow-wrap: anywhere;
   backdrop-filter: blur(5px);
 }
 .card i {
@@ -229,4 +231,5 @@ section {
   .hero-grid { grid-template-columns: 1fr; text-align: center; }
   .hero-image { order: -1; }
   .logo img { width: 120px; }
+  .card { width: 100%; }
 }

--- a/css/revisar-sugerencias.css
+++ b/css/revisar-sugerencias.css
@@ -109,7 +109,7 @@ button {
   cursor: pointer;
   margin-top: 20px;
   transition: background 0.3s ease, transform 0.2s ease;
-  min-height: 44px;
+  min-height: 48px;
 }
 
 button:hover,

--- a/css/sugerencias.css
+++ b/css/sugerencias.css
@@ -85,6 +85,8 @@ body.light-mode #toggle-modo::before {
   border-radius: 20px;
   width: 100%;
   max-width: 600px;
+  max-height: 90vh;
+  overflow-y: auto;
   box-shadow: 0 0 20px rgba(0,0,0,0.5);
   animation: fadeIn 0.5s ease-in-out;
 }
@@ -109,7 +111,7 @@ select, input, textarea, button {
   border-radius: 8px;
   border: none;
   font-size: 16px;
-  min-height: 44px; /* ✅ tamaño táctil */
+  min-height: 48px; /* ✅ tamaño táctil */
 }
 
 input, textarea, select {
@@ -135,7 +137,7 @@ button {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
   padding: 10px 16px;
   border: none;
-  min-height: 44px;
+  min-height: 48px;
 }
 
 button:hover,

--- a/css/traductor.css
+++ b/css/traductor.css
@@ -62,7 +62,7 @@ body.dark-mode .chat-container {
   margin-left: 0.5rem;
   color: var(--text-color);
   transition: color 0.3s ease, transform 0.3s ease;
-  min-height: 44px; /* ✅ tamaño táctil */
+  min-height: 48px; /* ✅ tamaño táctil */
 }
 
 .chat-header button:hover {
@@ -103,7 +103,7 @@ body.dark-mode .chat-container {
   border: 1px solid #ccc;
   font-size: 1rem;
   resize: none;
-  height: 42px;
+  min-height: 48px;
   line-height: 1.3;
 }
 .chat-form textarea:focus {
@@ -132,7 +132,7 @@ body.dark-mode .chat-container {
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 44px; /* ✅ tamaño táctil */
+  min-height: 48px; /* ✅ tamaño táctil */
 }
 .chat-form button:hover { background: #e44827; }
 


### PR DESCRIPTION
## Summary
- update button and input min-height to 48px
- allow content to wrap in result and cards
- constrain modals and forms for small screens
- tweak chat layouts for mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684712d4e008832b818547e2e2f3ee60