### PR TITLE
Enhance mobile layout

### DIFF
--- a/css/chat-modal.css
+++ b/css/chat-modal.css
@@ -33,7 +33,9 @@ body.dark-mode {
   box-shadow: 0 4px 20px rgba(0,0,0,0.1);
   width: 100%;
   max-width: 900px;
-  height: 90vh;
+  height: calc(90vh - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+  margin-top: env(safe-area-inset-top);
+  margin-bottom: env(safe-area-inset-bottom);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -74,7 +76,7 @@ body.dark-mode {
 @media (max-width: 600px) {
   #sparkie-modal .chat-container {
     width: 95vw;
-    height: 90vh;
+    height: calc(90vh - env(safe-area-inset-top) - env(safe-area-inset-bottom));
     border-radius: 12px;
   }
 }

--- a/css/estilos.css
+++ b/css/estilos.css
@@ -30,6 +30,10 @@ body {
   background-attachment: fixed;
   color: white;
   font-family: 'Segoe UI', sans-serif;
+  padding-top: env(safe-area-inset-top);
+  padding-right: env(safe-area-inset-right);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
 }
 
 .contenedor-pagina {
@@ -130,11 +134,19 @@ h1 span {
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
   transition: all 0.3s ease;
   min-height: 48px;
+
 }
 body.light-mode .busqueda input {
   background-color: #f3f3f3;
   color: #111;
 }
+.botones-busqueda {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
 
 /* === CONTENEDOR PRINCIPAL === */
 .ventana {
@@ -143,6 +155,7 @@ body.light-mode .busqueda input {
   border-radius: 20px;
   max-width: 960px;
   width: 90%;
+  margin: 0 auto;
   box-shadow: 0 0 20px rgba(0,0,0,0.5);
   animation: fadeIn 0.5s ease-in-out;
   text-align: center;
@@ -301,6 +314,23 @@ body.light-mode #contadorTerminos {
 body.light-mode #toggle-modo::before {
   content: '☀️';
   transform: translateX(30px);
+}
+
+/* === BOTÓN MENÚ === */
+.menu-toggle {
+  position: fixed;
+  top: 10px;
+  left: 10px;
+  width: 48px;
+  height: 48px;
+  background: #3f51b5;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 1.5rem;
+  cursor: pointer;
+  z-index: 1002;
+  display: none;
 }
 
 /* === NAVEGACIÓN === */
@@ -582,6 +612,7 @@ body {
   z-index: 1001;
   max-width: 400px;
   width: 90%;
+  margin: 0 auto;
   overflow-wrap: anywhere;
 }
 .ventana-sugerencia textarea,
@@ -619,25 +650,14 @@ body {
 
 /* === AJUSTES RESPONSIVOS === */
 @media (max-width: 768px) {
-  .ventana {
-    padding: 20px;
-  }
-  .nav-flotante {
-    flex-wrap: wrap;
-    gap: 8px;
-  }
-  .nav-flotante button {
-    flex: 1 1 45%;
-  }
-  .resultado-flex {
-    flex-direction: column;
-  }
-
-  .ventana-sugerencia {
-    top: 10%;
-    max-height: 80vh;
-    overflow-y: auto;
-  }
+  .menu-toggle { display: block; }
+  .nav-flotante { top: 0; left: 0; right: auto; width: 220px; height: 100vh; flex-direction: column; align-items: flex-start; background: rgba(30,30,30,0.95); padding: 80px 10px 10px; transform: translateX(-100%); transition: transform 0.3s ease; }
+  body.light-mode .nav-flotante { background: rgba(255,255,255,0.95); }
+  .nav-flotante.abierto { transform: translateX(0); }
+  .nav-flotante button { width: 100%; text-align: left; }
+  .ventana { padding: 20px; }
+  .resultado-flex { flex-direction: column; }
+  .ventana-sugerencia { top: 10%; max-height: 80vh; overflow-y: auto; }
 }
 @media (display-mode: standalone) {
   body {

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
   <button id="toggle-modo" onclick="toggleModo()" title="Cambiar modo claro/oscuro" aria-label="Cambiar modo claro u oscuro">
     <i class="fas fa-moon" id="icono-modo"></i>
   </button>
+  <button id="menu-toggle" class="menu-toggle" aria-label="Abrir menú">&#9776;</button>
 
   <div class="zona-moleculas">
     <img src="img/mol/mol-1.png" class="molecula" style="top: 5%; left: 5%;" alt="mol-1" />
@@ -59,9 +60,9 @@
       </div>
 
       <div class="botones-busqueda">
-        <button id="btnBuscar" class="boton" title="Buscar"><i class="fas fa-search"></i></button>
-        <button id="btnLimpiar" class="boton" title="Limpiar búsqueda"><i class="fas fa-eraser"></i></button>
-        <button id="btnActualizar" class="boton" title="Actualizar glosario"><i class="fas fa-rotate"></i></button>
+        <button id="btnBuscar" class="boton" aria-label="Buscar" title="Buscar"><i class="fas fa-search"></i></button>
+        <button id="btnLimpiar" class="boton" aria-label="Limpiar" title="Limpiar búsqueda"><i class="fas fa-eraser"></i></button>
+        <button id="btnActualizar" class="boton" aria-label="Actualizar" title="Actualizar glosario"><i class="fas fa-rotate"></i></button>
       </div>      
 
       <div id="estadoConexion" class="estado-conexion"></div>
@@ -97,7 +98,7 @@
   </div>
 
   <!-- Sparkie -->
-  <div id="sparkie-boton" title="Habla con Sparkie">
+  <div id="sparkie-boton" role="button" aria-label="Hablar con Sparkie" title="Habla con Sparkie">
     <img src="img/sparkie.png" alt="Sparkie" />
     <div id="sparkie-burbuja" class="oculto">¿Tienes dudas? ¡Habla con Sparkie!</div>
   </div>
@@ -108,8 +109,8 @@
         <button id="btn-regresar" class="cerrar-chat" title="Cerrar">&times;</button>
         <span> Chat con <strong>Sparkie AI</strong></span>
         <div class="botones-header">
-          <button id="toggle-sonido" title="Sonido activado"><i class="fas fa-volume-up"></i></button>
-          <button id="toggle-tema" title="Cambiar tema"><i class="fas fa-circle-half-stroke"></i></button>
+          <button id="toggle-sonido" aria-label="Activar o desactivar sonido" title="Sonido activado"><i class="fas fa-volume-up"></i></button>
+          <button id="toggle-tema" aria-label="Cambiar tema" title="Cambiar tema"><i class="fas fa-circle-half-stroke"></i></button>
         </div>
       </header>
       <main id="chat" class="chat-body"></main>
@@ -148,6 +149,16 @@
     }
 
     document.addEventListener("DOMContentLoaded", () => {
+      const menuToggle = document.getElementById("menu-toggle");
+      const nav = document.querySelector(".nav-flotante");
+      menuToggle.addEventListener("click", () => {
+        nav.classList.toggle("abierto");
+        menuToggle.setAttribute("aria-expanded", nav.classList.contains("abierto"));
+      });
+      nav.querySelectorAll("button").forEach(b => b.addEventListener("click", () => {
+        nav.classList.remove("abierto");
+        menuToggle.setAttribute("aria-expanded","false");
+      }));
       if (localStorage.getItem("modoClaro") === "1") {
         document.body.classList.add("light-mode");
         document.getElementById("icono-modo").className = "fas fa-sun";


### PR DESCRIPTION
## Summary
- add safe-area padding to body
- create responsive hamburger menu with slide-out navigation
- keep buttons grouped neatly on mobile
- adjust Sparkie chat modal for safe areas
- include ARIA labels for accessibility

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_68471cd4f950832baeec22a4cf20bc5e