### PR TITLE
Add service worker update banner

### DIFF
--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -55,3 +55,9 @@ self.addEventListener('fetch', event => {
       .catch(() => caches.match(event.request))
   );
 });
+
+self.addEventListener('message', event => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});


### PR DESCRIPTION
## Summary
- detect new service worker versions from `main.js`
- show an update banner and reload when confirmed
- handle `SKIP_WAITING` message in `serviceWorker.js`

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6847239b5624832bbba8d1973e0dd2c6