### PR TITLE
Replace alerts with SweetAlert2

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -8,6 +8,7 @@
   <meta name="theme-color" content="#00FFD0" />
   <link rel="stylesheet" href="css/admin.css">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
   <script defer src="js/admin.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
 </head>

--- a/comparador.html
+++ b/comparador.html
@@ -30,6 +30,7 @@
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
   <script src="js/comparador.js"></script>
 </body>
 </html>

--- a/contacto.html
+++ b/contacto.html
@@ -70,6 +70,7 @@
     <p>© 2025 Diccionario AR – Todos los derechos reservados</p>
   </footer>
 
+  <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
   <script src="js/contacto.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -138,6 +138,7 @@
 
   <!-- Scripts -->
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
   <script src="js/main.js" defer></script>
   <script src="js/eventosFestivos.js" defer></script>
   <script src="js/sparkieModal.js" defer></script>

--- a/js/admin.js
+++ b/js/admin.js
@@ -65,7 +65,10 @@ async function verificarClave() {
   });
 
   if (error || !data.session) {
-    alert("Usuario o contraseña incorrectos.");
+    await Swal.fire({
+      icon: 'error',
+      text: 'Usuario o contraseña incorrectos.'
+    });
     document.getElementById("clave").value = "";
     return;
   }
@@ -178,7 +181,13 @@ function mostrarPagina(nro) {
 // === EDITAR ===
 async function editarFila(id) {
   const fila = datosCrudos.find(d => d.id === id);
-  if (!fila) return alert("ID no encontrado");
+  if (!fila) {
+    await Swal.fire({
+      icon: 'error',
+      text: 'ID no encontrado'
+    });
+    return;
+  }
 
   const actualizado = {
     termino: prompt("Término:", fila.termino) ?? fila.termino,

--- a/js/comparador.js
+++ b/js/comparador.js
@@ -46,7 +46,10 @@ function comparar() {
   const nombre2 = document.getElementById('termino2').value.trim();
 
   if (!nombre1 || !nombre2 || nombre1 === nombre2) {
-    alert('Selecciona dos términos distintos');
+    Swal.fire({
+      icon: 'warning',
+      text: 'Selecciona dos términos distintos'
+    });
     return;
   }
 

--- a/js/contacto.js
+++ b/js/contacto.js
@@ -11,12 +11,18 @@ document.addEventListener("DOMContentLoaded", () => {
       const mensaje = document.getElementById("mensaje").value.trim();
   
       if (!nombre || !email || !mensaje) {
-        alert("Por favor, completa todos los campos.");
+        Swal.fire({
+          icon: 'warning',
+          text: 'Por favor, completa todos los campos.'
+        });
         return;
       }
   
       // Simular envío con mensaje de confirmación
-      alert("✅ ¡Gracias por tu mensaje! Nos pondremos en contacto pronto.");
+      Swal.fire({
+        icon: 'success',
+        text: '✅ ¡Gracias por tu mensaje! Nos pondremos en contacto pronto.'
+      });
   
       // Opcional: limpiar formulario
       formulario.reset();

--- a/js/main.js
+++ b/js/main.js
@@ -260,7 +260,10 @@ document.addEventListener("DOMContentLoaded", () => {
   document.getElementById("btnActualizar")?.addEventListener("click", actualizarGlosario);
   document.getElementById("btn-sugerir")?.addEventListener("click", () => {
     if (!ultimaBusqueda) {
-      alert("Busca un término antes de sugerir.");
+      Swal.fire({
+        icon: 'info',
+        text: 'Busca un término antes de sugerir.'
+      });
       return;
     }
     document.getElementById("ventana-sugerencia").classList.remove("oculto");


### PR DESCRIPTION
## Summary
- swap out browser alerts for SweetAlert2 popups
- include SweetAlert2 on pages that rely on alerts

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6850a4e6fea8832b80bb8e6b242917e0